### PR TITLE
smaller binaries

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -127,6 +127,11 @@ test-setup:
 
 #------------------------------------------------------------------------------#
 # openssl
+#
+# not all of openssl is needed, only the parts that Tor needs
+# https://trac.torproject.org/projects/tor/ticket/32200
+# https://gitweb.torproject.org/tor.git/tree/src/lib/tls/ciphers.inc
+# https://wiki.openssl.org/index.php/Compilation_and_Installation
 
 PATH := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64/bin:$(PATH)
 
@@ -134,7 +139,10 @@ PATH := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64/bin:$(PATH)
 openssl/Makefile: openssl/Configure $(wildcard openssl/Configurations/*.*)
 	cd openssl && PATH=$(PATH) \
 		./Configure \
-			no-shared \
+			no-comp no-dtls no-ec2m no-psk no-srp no-ssl2 no-ssl3 \
+			no-camellia no-idea no-md2 no-md4 no-mdc2 no-rc2 no-rc4 no-rc5 no-rmd160 no-whirlpool \
+			no-dso no-engine no-hw no-ui-console \
+			no-shared no-unit-test \
 			android-$(NDK_ABI) \
 			-D__ANDROID_API__=$(NDK_PLATFORM_LEVEL) \
 			--prefix=$(EXTERNAL_ROOT) \

--- a/external/Makefile
+++ b/external/Makefile
@@ -100,7 +100,7 @@ REPRODUCIBLE_CFLAGS := \
 #  -Wl,--no-insert-timestamp
 #  -fmacro-prefix-map=OLD=NEW
 
-ALL_CFLAGS := $(REPRODUCIBLE_CFLAGS) $(CFLAGS)
+ALL_CFLAGS := $(REPRODUCIBLE_CFLAGS) $(CFLAGS) -Os
 export CFLAGS := $(ALL_CFLAGS) -I$(EXTERNAL_ROOT)/include
 
 

--- a/external/Makefile
+++ b/external/Makefile
@@ -265,6 +265,7 @@ tor/Makefile: tor/configure.ac tor/Makefile.am
 				--enable-static-libevent --with-libevent-dir=$(EXTERNAL_ROOT) \
 				--enable-static-openssl --with-openssl-dir=$(EXTERNAL_ROOT) \
 				--enable-zstd \
+				--disable-module-dirauth \
 				--prefix=$(EXTERNAL_ROOT)
 	grep -E '^# *define +HAVE_LZMA +1$$' tor/orconfig.h
 	grep -E '^# *define +HAVE_ZSTD +1$$' tor/orconfig.h


### PR DESCRIPTION
This includes the three new techniques for making the binaries smaller:
* exclude the directory authority module
* exclude unused features in the openssl build
* build using `-Os` rather than `-O2` to optimize for file size

https://trac.torproject.org/projects/tor/ticket/32200
closes #18 

The test build run is here:
https://gitlab.com/eighthave/tor-android/pipelines/95692178

@n8fr8 @sisbell @sysrqb