### PR TITLE
fix(README): Broken/obsolete FAQ links

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,6 @@ is reasonably secure, but please ensure you read the instructions and
 configure it properly. Learn more at https://torproject.org/
 
 Tor Frequently Asked Questions:
-        https://wiki.torproject.org/noreply/TheOnionRouter/TorFAQ
-        https://www.torproject.org/faq.html.en
+        https://2019.www.torproject.org/docs/faq
+        https://support.torproject.org/faq/
 


### PR DESCRIPTION
Update Wiki FAQ link to non-obsolete FAQ; Update torproject.org link to non-404.