### PR TITLE
Do not always send debug logging to file

### DIFF
--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -330,7 +330,6 @@ public class TorService extends Service {
 
                             // can be moved to ControlPort messages
                             "--LogMessageDomains", "1",
-                            "--Log", "debug file " + new File(getCacheDir(), TAG + "-debug.log").getAbsolutePath(),
                             "--TruncateLogFile", "1"
                     ));
                     String[] verifyLines = lines.toArray(new String[0]);


### PR DESCRIPTION
This crashes Android devices by filling up the data partition
with a huge log file.