### PR TITLE
Prevent concurrent calls to Tor API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.3.3'
     }
 }
 

--- a/sampletorapp/src/main/AndroidManifest.xml
+++ b/sampletorapp/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -47,9 +47,10 @@ dependencies {
     api 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     api 'info.guardianproject:jtorctl:0.4.2.5'
 
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'info.guardianproject.netcipher:netcipher:2.1.0'
     androidTestImplementation 'commons-io:commons-io:2.6'
     androidTestImplementation 'commons-net:commons-net:3.6'

--- a/tor-android-binary/src/androidTest/java/org/torproject/jni/TorServiceDoubleUnbindTest.java
+++ b/tor-android-binary/src/androidTest/java/org/torproject/jni/TorServiceDoubleUnbindTest.java
@@ -1,0 +1,89 @@
+package org.torproject.jni;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.torproject.jni.TorService.ACTION_STATUS;
+import static org.torproject.jni.TorService.EXTRA_STATUS;
+import static org.torproject.jni.TorService.STATUS_OFF;
+import static org.torproject.jni.TorService.STATUS_ON;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.ServiceConnection;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ServiceTestRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(AndroidJUnit4.class)
+public class TorServiceDoubleUnbindTest {
+
+    public static final String TAG = "TorServiceTest";
+
+    @Rule
+    public final ServiceTestRule serviceRule = ServiceTestRule.withTimeout(120L, TimeUnit.SECONDS);
+
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = getInstrumentation().getTargetContext();
+    }
+
+    /**
+     * Test using {@link ServiceTestRule#bindService(Intent, ServiceConnection, int)}
+     * for reliable start/stop when testing.
+     */
+    @Test
+    public void testBindService() throws Exception {
+        startAndUnbind();
+        startAndUnbind();
+    }
+
+    private void startAndUnbind() throws Exception {
+        final CountDownLatch startedLatch = new CountDownLatch(1);
+        final CountDownLatch stoppedLatch = new CountDownLatch(1);
+        BroadcastReceiver receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                String status = intent.getStringExtra(EXTRA_STATUS);
+                Log.i(TAG, "receiver.onReceive: " + status + " " + intent);
+                if (STATUS_ON.equals(status)) {
+                    startedLatch.countDown();
+                } else if (STATUS_OFF.equals(status)) {
+                    stoppedLatch.countDown();
+                }
+            }
+        };
+        // run the BroadcastReceiver in its own thread
+        HandlerThread handlerThread = new HandlerThread(receiver.getClass().getSimpleName());
+        handlerThread.start();
+        Looper looper = handlerThread.getLooper();
+        Handler handler = new Handler(looper);
+        context.registerReceiver(receiver, new IntentFilter(ACTION_STATUS), null, handler);
+
+        Intent serviceIntent = new Intent(context, TorService.class);
+        IBinder binder = serviceRule.bindService(serviceIntent);
+        TorService torService = ((TorService.LocalBinder) binder).getService();
+        startedLatch.await();
+
+        serviceRule.unbindService();
+        stoppedLatch.await();
+
+        context.unregisterReceiver(receiver);
+    }
+
+}

--- a/tor-android-binary/src/androidTest/java/org/torproject/jni/TorServiceTest.java
+++ b/tor-android-binary/src/androidTest/java/org/torproject/jni/TorServiceTest.java
@@ -155,7 +155,7 @@ public class TorServiceTest {
         assertTrue("NetCipher.getHttpURLConnection should use Tor",
                 NetCipher.isNetCipherGetHttpURLConnectionUsingTor());
 
-        URLConnection c = NetCipher.getHttpsURLConnection("https://www.nytimes3xbfgragh.onion/");
+        URLConnection c = NetCipher.getHttpsURLConnection("https://www.nytimesn7cgmftshazwhfgzm37qxb44r64ytbb2dj3x62d2lljsciiyd.onion/");
         Log.i(TAG, "Content-Length: " + c.getContentLength());
         Log.i(TAG, "CONTENTS: " + new String(IOUtils.readFully(c.getInputStream(), 100)));
 
@@ -242,7 +242,7 @@ public class TorServiceTest {
         // ~350MB
         //URL url = new URL("http://dl.google.com/android/ndk/android-ndk-r9b-linux-x86_64.tar.bz2");
         // ~3MB
-        URL url = new URL("http://dl.google.com/android/repository/platform-tools_r24-linux.zip");
+        URL url = new URL("https://dl.google.com/android/repository/platform-tools_r24-linux.zip");
         // 55KB
         //URL url = new URL("https://jcenter.bintray.com/com/android/tools/build/gradle/2.2.3/gradle-2.2.3.jar");
         HttpURLConnection connection = NetCipher.getHttpURLConnection(url);


### PR DESCRIPTION
This PR prevents the crashes seen in ~~#57 and~~ [Tor #32729](https://gitlab.torproject.org/tpo/core/tor/-/issues/32729) by preventing concurrent calls to the Tor API. Concurrent calls are prevented in two ways:

1. Move the call to mainConfigurationFree() onto the same thread as runMain() to ensure it's never called before runMain() has returned, per the comments in tor_api.h.

2. Use a static lock to prevent different TorService instances within the same process from making concurrent native calls. It was previously possible for this to happen because the native calls are made from a background thread that may (briefly) outlive the TorService instance that launched it.

Edit: The crashes seen in #57 seem to be caused by file descriptor reuse and are not fixed by this PR.