### PR TITLE
Allow TorService to be used in a separate process

### DIFF
--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.so'])
     api 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    api 'info.guardianproject:jtorctl:0.4.2.5'
+    api 'info.guardianproject:jtorctl:0.4.5.7'
 
     androidTestImplementation 'androidx.test:core:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -115,6 +115,10 @@ public class TorService extends Service {
         return new File(getAppTorServiceDir(context), "torrc-defaults");
     }
 
+    public static FileDescriptor getControlSocketFileDescriptor(Context context) {
+        return prepareFileDescriptor(getControlSocket(context).getAbsolutePath());
+    }
+
     private static File getControlSocket(Context context) {
         if (controlSocket == null) {
             controlSocket = new File(getAppTorServiceDataDir(context), CONTROL_SOCKET_NAME);
@@ -264,7 +268,7 @@ public class TorService extends Service {
                     throw new IllegalStateException("cannot read " + controlSocket);
                 }
 
-                FileDescriptor controlSocketFd = prepareFileDescriptor(getControlSocket(TorService.this).getAbsolutePath());
+                FileDescriptor controlSocketFd = getControlSocketFileDescriptor(TorService.this);
                 InputStream is = new FileInputStream(controlSocketFd);
                 OutputStream os = new FileOutputStream(controlSocketFd);
                 torControlConnection = new TorControlConnection(is, os);

--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -60,6 +60,12 @@ public class TorService extends Service {
     private static final String ACTION_STOP = "org.torproject.android.intent.action.STOP";
 
     /**
+     * A integer intent extra containing the PID of the owning process,
+     * if this service is run in a dedicated process.
+     */
+    public static final String EXTRA_PID = "org.torproject.android.intent.extra.PID";
+
+    /**
      * {@link Intent} sent by this app with {@code ON/OFF/STARTING/STOPPING} status
      * included as an {@link #EXTRA_STATUS} {@code String}.  Your app should
      * always receive {@code ACTION_STATUS Intent}s since any other app could
@@ -171,6 +177,8 @@ public class TorService extends Service {
     private long torConfiguration = -1;
     private int torControlFd = -1;
 
+    private int owningProcessPid = -1;
+
     private TorControlConnection torControlConnection;
 
     /**
@@ -204,6 +212,7 @@ public class TorService extends Service {
 
     @Override
     public IBinder onBind(Intent intent) {
+        owningProcessPid = intent.getIntExtra(EXTRA_PID, -1);
         return binder;
     }
 
@@ -350,6 +359,10 @@ public class TorService extends Service {
                                 "--LogMessageDomains", "1",
                                 "--TruncateLogFile", "1"
                         ));
+                        if (owningProcessPid != -1) {
+                            lines.add("--__OwningControllerProcess");
+                            lines.add(Integer.toString(owningProcessPid));
+                        }
                         String[] verifyLines = lines.toArray(new String[0]);
                         if (!mainConfigurationSetCommandLine(verifyLines)) {
                             throw new IllegalArgumentException("Setting command line failed: " + Arrays.toString(verifyLines));
@@ -381,6 +394,7 @@ public class TorService extends Service {
                         mainConfigurationFree();
                         Log.i(TAG, "Releasing lock");
                         runLock.unlock();
+                        if (owningProcessPid != -1) stopSelf();
                     }
 
                 } catch (IllegalStateException | IllegalArgumentException | InterruptedException e) {


### PR DESCRIPTION
Running `TorService` in a separate process has a couple of advantages:

* when Tor crashes, the app doesn't crash with it
* Tor can be restarted frequently without crashing (e.g. [`tor#23847`](https://gitlab.torproject.org/tpo/core/tor/-/issues/23847) [`tor#23848`](https://gitlab.torproject.org/tpo/core/tor/-/issues/23848)) 
* might improve security

This PR enables that.

Note that this also upgrades `jtorctl`.