### PR TITLE
use "volatile" for key variables that are accessed across threads

### DIFF
--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -192,7 +192,7 @@ public class TorService extends Service {
     private long torConfiguration = -1;
     private int torControlFd = -1;
 
-    private TorControlConnection torControlConnection;
+    private volatile TorControlConnection torControlConnection;
 
     /**
      * This lock must be acquired before calling createTorConfiguration() and
@@ -310,7 +310,7 @@ public class TorService extends Service {
         }
     };
 
-    private CountDownLatch controlPortThreadStarted;
+    private volatile CountDownLatch controlPortThreadStarted;
 
     private int getPortFromGetInfo(String key) {
         final String value = getInfo(key);


### PR DESCRIPTION
Based on this discussion:
https://github.com/guardianproject/tor-android/issues/67#issuecomment-1043258065#67

CI is here:
https://gitlab.com/eighthave/tor-android/-/pipelines/522792599