### PR TITLE
Removes SOCKS/HTTP Proxy Hardcoding 

### DIFF
--- a/sampletorapp/src/main/java/org/torproject/android/sample/MainActivity.java
+++ b/sampletorapp/src/main/java/org/torproject/android/sample/MainActivity.java
@@ -29,8 +29,6 @@ import android.webkit.WebView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import net.freehaven.tor.control.TorControlConnection;
-
 import org.torproject.jni.TorService;
 
 public class MainActivity extends Activity {
@@ -65,9 +63,8 @@ public class MainActivity extends Activity {
 
                 //moved torService to a local variable, since we only need it once
                 TorService torService = ((TorService.LocalBinder) service).getService();
-                TorControlConnection conn = torService.getTorControlConnection();
 
-                while ((conn = torService.getTorControlConnection())==null)
+                while (torService.getTorControlConnection() ==null)
                 {
                     try {
                         Thread.sleep(500);
@@ -76,10 +73,7 @@ public class MainActivity extends Activity {
                     }
                 }
 
-                if (conn != null)
-                {
-                    Toast.makeText(MainActivity.this, "Got Tor control connection", Toast.LENGTH_LONG).show();
-                }
+                Toast.makeText(MainActivity.this, "Got Tor control connection", Toast.LENGTH_LONG).show();
             }
 
             @Override

--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -408,6 +408,7 @@ public class TorService extends Service {
 
     private int getPortFromGetInfo(String key) {
         final String value = getInfo(key);
+        if (value.trim().isEmpty()) return 0; // port is disabled
         return Integer.parseInt(value.substring(value.lastIndexOf(':') + 1, value.length() - 1));
     }
 


### PR DESCRIPTION
This enables people to set these values from their torrc. Setting these options as command line args prevents any users of tor-android to configure these properties differently. I tried to preserve all default behavior by providing sensible defaults in the event that the user does not set them. 

This also fixes #79 

This is needed to fix a range of Orbot issues: 
- https://github.com/guardianproject/orbot/issues/709
- https://github.com/guardianproject/orbot/issues/708
- https://github.com/guardianproject/orbot/issues/707
- https://github.com/guardianproject/orbot/issues/317 