### PR TITLE
Zlib update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ daemon.  Binaries are available on Maven Central:
 
 ```gradle
 dependencies {
-    implementation 'info.guardianproject:tor-android:0.4.7.10'
+    implementation 'info.guardianproject:tor-android:0.4.7.11'
     implementation 'info.guardianproject:jtorctl:0.4.5.7'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@ allprojects {
 ext {
     minSdkVersion = 19
     targetSdkVersion = 33
-    versionCode = 4710
-    versionName = "0.4.7.10"
+    versionCode = 4711
+    versionName = "0.4.7.11"
 }


### PR DESCRIPTION
zlib is chosen by tor before xz and zstd, so lets update to latest bugfix release tag.