### PR TITLE
🐛 add missing tool (po4a) to ci script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ cache:
       make
       patch
       pkg-config
+      po4a
 
 - export GRADLE_USER_HOME=$PWD/.gradle
 


### PR DESCRIPTION
Running builds in vagrant container was failing for me because building xz now apparently needs po4a (a translation tool) for successfully running builds.  This change installs the dependency with apt, into both gitlab-CI and vagrant build environments.

Here's the relevant output of `./tor-droid-make.sh release -f`:

```
+ sh update-po
po4a/update-po: The program 'po4a' was not found.
po4a/update-po: Translated man pages were not generated.
make: *** [Makefile:200: xz/Makefile] Error 1
make: Leaving directory '/builds/guardianproject/tor-android/external'
```