### PR TITLE
🐢 update gradlew hash

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=336b6898b491f6334502d8074a6b8c2d73ed83b92123106bd4bf837f04111043
+distributionSha256Sum=cd5c2958a107ee7f0722004a12d0f8559b4564c34daad7df06cffd4d12a426d0
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
It seems the graldew was updated without updating the download checksum in gradle-wrapper.properties. This breaks the build automation in gitlab CI and vagrant. (The correct checksum can be looked up here: https://gradle.org/release-checksums/#v7.4 )

Here's the error message I got when trying to run `tor-droid-make.sh release -f` in vagrant without this change:

```
Downloading https://services.gradle.org/distributions/gradle-7.4-all.zip
...............................................................................................................
........................................
Verification of Gradle distribution failed!

Your Gradle distribution may have been tampered with.
Confirm that the 'distributionSha256Sum' property in your gradle-wrapper.properties file is correct and you are downloading the wrapper from a trusted source.

 Distribution Url: https://services.gradle.org/distributions/gradle-7.4-all.zip
Download Location: /root/.gradle/wrapper/dists/gradle-7.4-all/aadb4xli5jkdsnukm30eibyiu/gradle-7.4-all.zip
Expected checksum: '336b6898b491f6334502d8074a6b8c2d73ed83b92123106bd4bf837f04111043'
  Actual checksum: 'cd5c2958a107ee7f0722004a12d0f8559b4564c34daad7df06cffd4d12a426d0'
```