### PR TITLE
Add elf-cleaner to clean unwanted ELF flags

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = external/zlib
 	url = https://github.com/madler/zlib
 	ignore = dirty
+[submodule "external/elf-cleaner"]
+	path = external/elf-cleaner
+	url = https://github.com/termux/termux-elf-cleaner
+	ignore = dirty

--- a/external/Makefile
+++ b/external/Makefile
@@ -331,6 +331,7 @@ ifneq ($(DEBUG), 1)
 	##	$(INSTALL_DIR)/libtor.so
 	$(NDK_TOOLCHAIN_BASE)/bin/llvm-strip --strip-unneeded -R .note -R .comment --strip-debug \
 		$(INSTALL_DIR)/libtor.so
+	$(EXTERNAL_ROOT)/bin/termux-elf-cleaner --api-level $(NDK_PLATFORM_LEVEL) $(INSTALL_DIR)/libtor.so
 	ls -l  $(INSTALL_DIR)/libtor.so
 endif
 	@echo "check if all the libs got included:"

--- a/external/build-tools
+++ b/external/build-tools
@@ -1,0 +1,32 @@
+EXTERNAL_ROOT := $(shell pwd)
+
+MAKE ?= make -j`nproc`
+
+.PHONY = elf-cleaner-clean
+
+all: PREBUILD_EXECUTABLE
+
+#------------------------------------------------------------------------------#
+# elf-cleaner
+
+elf-cleaner/Makefile:
+	cd elf-cleaner && autoreconf --install
+	cd elf-cleaner && ./configure --prefix=/
+
+elf-cleaner-build-stamp: elf-cleaner/Makefile
+	$(MAKE) -C elf-cleaner install DESTDIR=$(EXTERNAL_ROOT)
+	touch $@
+
+elf-cleaner-clean:
+	-rm -f bin/termux-elf-cleaner
+	-rm -f elf-cleaner-build-stamp
+	-$(MAKE) -C elf-cleaner uninstall DESTDIR=$(EXTERNAL_ROOT)
+	-$(MAKE) -C elf-cleaner clean
+	-cd elf-cleaner && \
+                git clean -fdx > /dev/null
+
+elf-cleaner: elf-cleaner-build-stamp
+
+PREBUILD_EXECUTABLE: elf-cleaner
+
+clean: elf-cleaner-clean

--- a/tor-droid-make.sh
+++ b/tor-droid-make.sh
@@ -52,6 +52,10 @@ check_android_dependencies()
 build_external_dependencies()
 {
     check_android_dependencies
+    if [ -f external/bin/termux-elf-cleaner ]; then
+        make -C external -f build-tools clean
+    fi
+    make -C external -f build-tools
     for abi in $abis; do
 	default_abis=`echo $default_abis | sed -E "s,(\s?)$abi(\s?),\1\2,"`
 	APP_ABI=$abi make -C external clean


### PR DESCRIPTION
Fixes warning on Android devices running API <= 25:

WARNING: linker: /data/app/org.torproject.android-1/lib/arm64/libtor.so: unsupported flags DT_FLAGS_1=0x8000001