### PR TITLE
NDK 25+ requires minSDK 19

### DIFF
--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -17,7 +17,7 @@ android {
     buildToolsVersion '33.0.0'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
Updating to NDK 25+ requires minSDK 19.  Be consistent with the other build.gradle configurations.