### PR TITLE
Update to gradle 7.6.3 and latest stable AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.24.0' // NEW
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.10.2' // NEW
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,8 @@
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #aar.deployPath=/media/n8fr8/nate128/dev/repos/gpmaven
 aar.deployPath=/home/n8fr8/dev/repos/gpmaven
+android.defaults.buildfeatures.buildconfig=true
+android.disableAutomaticComponentCreation=false
 android.useAndroidX=true
 
 SONATYPE_HOST=DEFAULT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=cd5c2958a107ee7f0722004a12d0f8559b4564c34daad7df06cffd4d12a426d0
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionSha256Sum=6001aba9b2204d26fa25a5800bb9382cf3ee01ccb78fe77317b2872336eb2f80
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -14,7 +14,7 @@ def getVersionName = { ->
 
 android {
     compileSdkVersion 33
-    buildToolsVersion '33.0.0'
+    buildToolsVersion '33.0.2'
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
Update to latest stable gradle which includes fixes for CVE-2022-36033 and specify updated build tools made to support SDK 33.