### PR TITLE
Fix version code incrementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 ext {
     minSdkVersion = 19
     targetSdkVersion = 33
-    versionCode = 4870
+    versionCode = 4807
     versionName = "0.4.8.7"
     LIBRARY_GROUP = "info.guardianproject"
     LIBRARY_ARTIFACT_ID = "tor-android"


### PR DESCRIPTION
Tor 0.4.8.7 version code should be 4807 because it needs to be a lower number when Tor 0.4.8.10 is released (4810).