### PR TITLE
Enable GPL code for PoW Defense

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -291,6 +291,7 @@ tor/Makefile: tor/configure.ac tor/Makefile.am
 			./configure \
 				--host=$(ALTHOST) \
 				--enable-android \
+				--enable-gpl \
 				--enable-lzma \
 				--enable-pic \
 				--enable-static-libevent --with-libevent-dir=$(EXTERNAL_ROOT) \


### PR DESCRIPTION
Tor 0.4.8 requires enabling gpl code to enable new pow defense system.