### PR TITLE
Set min ndk version to API 21 for armeabi-v7a and x86

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 }
 
 ext {
-    minSdkVersion = 19
+    minSdkVersion = 21
     targetSdkVersion = 33
     versionCode = 4811
     versionName = "0.4.8.11"

--- a/external/Makefile
+++ b/external/Makefile
@@ -60,7 +60,7 @@ ifneq ($(filter armeabi-v7a, $(APP_ABI)),)
  GREP_CHECK := EABI5
  NDK_ABI := arm
  NDK_BIT := 32
- NDK_PLATFORM_LEVEL := 19
+ NDK_PLATFORM_LEVEL := 21
  NDK_TOOLCHAIN := $(HOST)-$(NDK_TOOLCHAIN_VERSION)
 endif
 ifneq ($(filter x86, $(APP_ABI)),)
@@ -69,7 +69,7 @@ ifneq ($(filter x86, $(APP_ABI)),)
  GREP_CHECK := 80386
  NDK_ABI := x86
  NDK_BIT := 32
- NDK_PLATFORM_LEVEL := 19
+ NDK_PLATFORM_LEVEL := 21
  NDK_TOOLCHAIN := $(NDK_ABI)-$(NDK_TOOLCHAIN_VERSION)
 endif
 ifneq ($(filter x86_64, $(APP_ABI)),)

--- a/external/Makefile
+++ b/external/Makefile
@@ -27,7 +27,7 @@ endif
 # matching NDK revisions are required for reproducible builds
 NDK_REVISION := $(shell sed -n 's,^Pkg.Revision *= *\([^ ]*\),\1,p' $(ANDROID_NDK_HOME)/source.properties)
 NDK_REQUIRED_REVISION := 25.2.9519653
-MIN_NDK_VERSION := 19
+MIN_NDK_VERSION := 21
 ifeq ($(shell test $(MIN_NDK_VERSION) -gt $(firstword $(subst ., ,$(NDK_REVISION))); echo $$?),0)
  $(error NDK r$(MIN_NDK_VERSION) or newer required! r$(NDK_REVISION) is installed at $(ANDROID_NDK_HOME).)
 endif
@@ -36,15 +36,15 @@ ifneq ($(NDK_REQUIRED_REVISION), $(NDK_REVISION))
 endif
 
 
-ifneq ($(filter mips%, $(APP_ABI)),)
- HOST := mipsel-linux-android
- ALTHOST := $(HOST)
- GREP_CHECK := MIPS
- NDK_ABI := mips
- NDK_BIT := 32
- NDK_PLATFORM_LEVEL := 19
- NDK_TOOLCHAIN := $(HOST)-$(NDK_TOOLCHAIN_VERSION)
-endif
+# ifneq ($(filter mips%, $(APP_ABI)),)
+#  HOST := mipsel-linux-android
+#  ALTHOST := $(HOST)
+#  GREP_CHECK := MIPS
+#  NDK_ABI := mips
+#  NDK_BIT := 32
+#  NDK_PLATFORM_LEVEL := 19
+#  NDK_TOOLCHAIN := $(HOST)-$(NDK_TOOLCHAIN_VERSION)
+# endif
 ifneq ($(filter arm64-v8a, $(APP_ABI)),)
  HOST := aarch64-linux-android
  ALTHOST := $(HOST)

--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -17,7 +17,7 @@ android {
     buildToolsVersion '33.0.2'
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21    
         targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
@eighthave I made this change regarding #140 - I believe these are set to 19 as a mistake. Orbot targets API 21 and for that matter tor browser for android sets this to 21 for each abi too