### PR TITLE
Add --disable-openssl to libevent build stamp. It's not needed for tor

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -179,6 +179,7 @@ libevent/Makefile: libevent/Makefile.am libevent/configure.ac
 				--host=$(ALTHOST) \
 				--disable-libevent-regress \
 				--disable-samples \
+				--disable-openssl \
 				--disable-shared \
 			        --prefix=/
 


### PR DESCRIPTION
and adds to compile time + binary size. Tor Browser disables this module on Android but also on all other platforms.