### PR TITLE
WIP: Disable many new openssl modules that don't impact tor

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -141,10 +141,12 @@ export ANDROID_NDK_ROOT=$(ANDROID_NDK_HOME)
 openssl/Makefile: openssl/Configure $(wildcard openssl/Configurations/*.*)
 	cd openssl && PATH=$(PATH) && CFLAGS="$(CFLAGS) -Wno-macro-redefined" \
 		./Configure \
-			no-comp no-dtls no-ec2m no-psk no-srp no-ssl3 \
+			no-comp no-dtls no-engine no-ec2m no-psk no-srp no-ssl3 \
 			no-camellia no-idea no-md2 no-md4 no-mdc2 no-rc2 no-rc4 no-rc5 no-rmd160 no-whirlpool \
-			no-dso no-hw no-ui-console \
+			no-dso no-ui-console \
 			no-shared no-tests \
+			no-siv no-sm2 no-sm3 no-sm4 \
+			no-dsa no-scrypt no-bf no-blake2 no-chacha \
 			android-$(NDK_ABI) \
 			-D__ANDROID_API__=$(NDK_PLATFORM_LEVEL) \
 			--prefix=/ \


### PR DESCRIPTION
These shave off a lot of MB especially when doing a universal build. I don't want to mess anything up here + deeper research & testing is needed before merging this ...