### PR TITLE
Remove lzma/xz from tor-android 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ cache:
       make
       patch
       pkg-config
-      po4a
+      
 
 - export GRADLE_USER_HOME=$PWD/.gradle
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 	path = external/zstd
 	url = https://github.com/facebook/zstd.git
 	ignore = dirty
-[submodule "external/xz"]
-	path = external/xz
-	url = https://git.tukaani.org/xz.git
-	ignore = dirty
 [submodule "external/zlib"]
 	path = external/zlib
 	url = https://github.com/madler/zlib

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@ First install the prerequisite packages:
 sudo apt install autotools-dev
 sudo apt install automake
 sudo apt install autogen autoconf libtool gettext-base autopoint
-sudo apt install git make g++ po4a pkg-config openjdk-17-jdk openjdk-17-jre
+sudo apt install git make g++ pkg-config openjdk-17-jdk openjdk-17-jre
 ```
 
 Then obtain the Android SDK and NDK. The Android SDK is installed by default with Android Studio, and the NDK can be downloaded from within Android Studio's SDK manager.

--- a/external/Makefile
+++ b/external/Makefile
@@ -303,8 +303,6 @@ ifneq ($(DEBUG), 1)
 	$(EXTERNAL_ROOT)/bin/termux-elf-cleaner --api-level $(NDK_PLATFORM_LEVEL) $(INSTALL_DIR)/libtor.so
 	ls -l  $(INSTALL_DIR)/libtor.so
 endif
-	@echo "check if all the libs got included:"
-# 	grep "tor_lzma_state_size_precalc" $(INSTALL_DIR)/libtor.so
 	install -d $(EXTERNAL_ROOT)/test/$(APP_ABI)
 	cp tor/src/test/test tor/src/test/test-memwipe tor/src/test/test-slow \
 		$(EXTERNAL_ROOT)/test/$(APP_ABI)

--- a/external/Makefile
+++ b/external/Makefile
@@ -111,7 +111,6 @@ INSTALL_DIR := $(EXTERNAL_ROOT)/lib/$(APP_ABI)
 	zlib-clean \
 	openssl-clean \
 	libevent-clean \
-	lzma-clean \
 	zstd-clean \
 	tor tor-clean
 
@@ -197,39 +196,6 @@ libevent-clean:
 
 
 #------------------------------------------------------------------------------#
-# lzma
-
-xz/Makefile: xz/configure.ac xz/Makefile.am
-	cd xz && ./autogen.sh
-	cd xz && ./configure \
-			--host=$(HOST) \
-			--enable-static \
-			--disable-doc \
-			--disable-lzma-links \
-			--disable-lzmadec \
-			--disable-lzmainfo \
-			--disable-scripts \
-			--disable-shared \
-			--disable-xz \
-			--disable-xzdec \
-			--prefix=/
-
-lzma-build-stamp: xz/Makefile
-	$(MAKE) -C xz install DESTDIR=$(EXTERNAL_ROOT)
-	touch $@
-
-lzma-clean:
-	-$(MAKE) -C xz uninstall DESTDIR=$(EXTERNAL_ROOT)
-	-$(MAKE) -C xz clean
-	-rm -rf include/lzma
-	-rm -f include/lzma.h
-	-rm -f lib/liblzma.a
-	-rm -f lib/liblzma.la
-	-rm -f lzma-build-stamp
-	-cd xz && \
-		git clean -fdx > /dev/null
-
-#------------------------------------------------------------------------------#
 # zlib
 
 zlib-build-stamp:
@@ -295,7 +261,6 @@ tor/Makefile: tor/configure.ac tor/Makefile.am
 				--host=$(ALTHOST) \
 				--enable-android \
 				--enable-gpl \
-				--enable-lzma \
 				--enable-pic \
 				--enable-static-libevent --with-libevent-dir=$(EXTERNAL_ROOT) \
 				--enable-static-openssl --with-openssl-dir=$(EXTERNAL_ROOT) \
@@ -304,7 +269,6 @@ tor/Makefile: tor/configure.ac tor/Makefile.am
 				--disable-module-dirauth \
 				--disable-asciidoc \
 				--prefix=$(EXTERNAL_ROOT)
-	grep -E '^# *define +HAVE_LZMA +1$$' tor/orconfig.h
 	grep -E '^# *define +HAVE_ZSTD +1$$' tor/orconfig.h
 	grep -E '^# *define +ENABLE_OPENSSL +1$$' tor/orconfig.h
 	grep -E '^# *define +HAVE_TLS_METHOD +1$$' tor/orconfig.h
@@ -313,7 +277,7 @@ tor-build-stamp: tor/Makefile
 	$(MAKE) -C tor
 	touch $@
 
-tor: zlib-build-stamp lzma-build-stamp zstd-build-stamp libevent-build-stamp openssl-build-stamp tor-build-stamp
+tor: zlib-build-stamp zstd-build-stamp libevent-build-stamp openssl-build-stamp tor-build-stamp
 
 tor-clean:
 	-rm -f $(OUTPUT_FILE)
@@ -340,7 +304,7 @@ ifneq ($(DEBUG), 1)
 	ls -l  $(INSTALL_DIR)/libtor.so
 endif
 	@echo "check if all the libs got included:"
-	grep "tor_lzma_state_size_precalc" $(INSTALL_DIR)/libtor.so
+# 	grep "tor_lzma_state_size_precalc" $(INSTALL_DIR)/libtor.so
 	install -d $(EXTERNAL_ROOT)/test/$(APP_ABI)
 	cp tor/src/test/test tor/src/test/test-memwipe tor/src/test/test-slow \
 		$(EXTERNAL_ROOT)/test/$(APP_ABI)
@@ -352,7 +316,7 @@ PREBUILD_SHARED_LIBRARY-clean:
 #------------------------------------------------------------------------------#
 # cleanup, cleanup, put the toys away
 
-clean: zlib-clean openssl-clean libevent-clean lzma-clean zstd-clean tor-clean
+clean: zlib-clean openssl-clean libevent-clean zstd-clean tor-clean
 
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/34202

We should be fine with zlib and zstd. This should reduce compile time, code/repository complexity and binary size.