### PR TITLE
--disable-module-dirauth does nothing without relay module also disabled

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -288,7 +288,6 @@ tor/Makefile: tor/configure.ac tor/Makefile.am
 				--enable-static-openssl --with-openssl-dir=$(EXTERNAL_ROOT) \
 				--enable-static-zlib --with-zlib-dir=$(EXTERNAL_ROOT) \
 				--enable-zstd \
-				--disable-module-dirauth \
 				--disable-asciidoc \
 				--prefix=$(EXTERNAL_ROOT)
 	grep -E '^# *define +HAVE_LZMA +1$$' tor/orconfig.h


### PR DESCRIPTION
https://gitlab.torproject.org/tpo/core/tor/-/issues/40904 i just learned that this never did anything 

At the time of this someone is running a relay with Orbot that uses the default name:
https://metrics.torproject.org/rs.html#details/53BAC9FA7F057BE66DCF4AA68FA2443847789D28

though I imagine a small handful of other people are using Orbot for relay stuff too 

Honestly the way Orbot is pitched as a lightweight VPN type app for bypassing censorship with some apps I feel like it hardly makes sense to use it as a relay. I could make a lightweight barebones app that uses TorService for people who want to run relays on Android and we could just chop this feature out of Orbot. I could see there being a small use case for this with people who have access to longrunning Android devices such as Android TVs or Chrome OS machines. To me the tradeoff seems worth it.

What do you think?

