### PR TITLE
Upgrade to Gradle 8 for Building in Newest Android Studio 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.9.0'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.24.0' // NEW
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.10.2' // NEW
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF
 #aar.deployPath=/media/n8fr8/nate128/dev/repos/gpmaven
 aar.deployPath=/home/n8fr8/dev/repos/gpmaven
 android.defaults.buildfeatures.buildconfig=true
-android.disableAutomaticComponentCreation=false
 android.useAndroidX=true
 
 SONATYPE_HOST=DEFAULT
@@ -47,3 +46,5 @@ POM_DEVELOPER_URL=https://github.com/guardianproject
 
 ossrhUsername=SONATYPE_USERNAME
 ossrhPassword=SONATYPE_PASSWORD
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Mon Mar 17 20:17:06 EDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=6001aba9b2204d26fa25a5800bb9382cf3ee01ccb78fe77317b2872336eb2f80
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sampletorapp/build.gradle
+++ b/sampletorapp/build.gradle
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'info.guardianproject:tor-android:0.4.8.11'
+    implementation 'info.guardianproject:tor-android:0.4.8.13.2'
     //implementation (name:'tor-android-binary-release',ext:'aar') //use this if you want to test your local AAR build
     implementation 'info.guardianproject:jtorctl:0.4.5.7'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/sampletorapp/src/main/java/org/torproject/android/sample/MainActivity.java
+++ b/sampletorapp/src/main/java/org/torproject/android/sample/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends Activity {
 
         GenericWebViewClient webViewClient = new GenericWebViewClient();
         webViewClient.setRequestCounterListener(requestCount ->
-                runOnUiThread(() -> statusTextView.setText("Request Count: " + requestCount)));
+                runOnUiThread(() -> statusTextView.setText("tor-android v: " + TorService.VERSION_NAME + " - Request Count: " + requestCount)));
         webView.setWebViewClient(webViewClient);
 
         registerReceiver(new BroadcastReceiver() {

--- a/tor-android-binary/build.gradle
+++ b/tor-android-binary/build.gradle
@@ -90,7 +90,7 @@ tasks.withType(AbstractArchiveTask) {
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    archiveClassifier.set("sources")
     archiveBaseName = 'tor-android-' + getVersionName()
 }
 
@@ -110,7 +110,7 @@ task javadoc(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
     archiveBaseName = 'tor-android-' + getVersionName()
 }

--- a/tor-android-binary/publishLocal.gradle
+++ b/tor-android-binary/publishLocal.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 task sourceJar(type: Jar) { 
     from android.sourceSets.main.java.srcDirs 
-    classifier "sources" 
+    archiveClassifier.set("sources") 
 } 
 
 project.afterEvaluate {
@@ -15,14 +15,14 @@ project.afterEvaluate {
         publishing { 
             publications { 
                 LibraryRelease(MavenPublication) { 
-                    from components.release 
+                    from components.findByName("release") 
                     artifact(sourceJar) 
                     setGroupId groupId 
                     setArtifactId artifactId 
                     version versionName + releaseSuffix 
                 } 
                 LibraryDebug(MavenPublication) { 
-                    from components.debug 
+                    from components.findByName("debug")
                     artifact(sourceJar) 
                     setGroupId groupId 
                     setArtifactId artifactId 


### PR DESCRIPTION
Gralde Updates, Wasn't able to build in newest Android Studio Meerkat | 2024.3.1 running on Debian...

- Upgrade `com.android.tools.build:gradle` -> 7.4.2->8.9.0
- Remove `-android.disableAutomaticComponentCreation=false`; Deprecated in gradle 8
- Update gradle wrapper to 8.11.1 from 7.6.3
- `classifier` replaced with `archiveClassifier` for src and doc jars

As I've never actually published this AAR as a resource with source JARs and javadoc JARs I'm not sure if the benign changes that I had made here as I resolved gradle issues messed up that part of the process. Would need for you to test this @n8fr8 

But ya, with these changes you can build the project in a fresh Android Studio and launch the sample app again! 