### PR TITLE
Remove build instruction telling to use older NDK toolchain v25...

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,13 +11,10 @@ sudo apt install git make g++ pkg-config openjdk-17-jdk openjdk-17-jre
 
 Then obtain the Android SDK and NDK. The Android SDK is installed by default with Android Studio, and the NDK can be downloaded from within Android Studio's SDK manager.
 
-for now, tor-android is built with NDK toolchain 25.2.9519654
-
 Then set these environment variables for the SDK and NDK:
-
 ```bash
 export ANDROID_HOME=~/Android/Sdk
-export ANDROID_NDK_HOME=~/Android/Sdk/ndk/25.2.9519653
+export ANDROID_NDK_HOME=~/Android/Sdk/ndk/29.0.13113456
 ```
 
 Be sure that you have all of the git submodules up-to-date:


### PR DESCRIPTION
@uniqx @n8fr8 

I remember last spring I was updating a lot of tor-android deps, specifically going from the very old openssl1 to openssl3 series. At the time, I couldn't get this project to build with any NDK toolchains newer than the 25 series. 

On a new machine running Debian Bookworm I just had success using the latest NDK toolchain offered by the SDK Manager in Android Studio version `29.0.13113456`. It's hard to diagnose what fixed things here.... In the past 10 months or so, numerous dependencies of tor-android have been updated, various other project config stuff has changed, etc.

But anyway, if this toolchain works for everyone, we should be using it, and **not** a deprecated version. 