### PR TITLE
Add sourcesJar task to fix build script

### DIFF
--- a/tor-android-binary/build.gradle.kts
+++ b/tor-android-binary/build.gradle.kts
@@ -82,6 +82,18 @@ dependencies {
     androidTestImplementation("commons-net:commons-net:3.6")
 }
 
+tasks {
+    val sourcesJar by creating(Jar::class) {
+        archiveBaseName.set("tor-android-" + getVersionName())
+        archiveClassifier.set("sources")
+        from(android.sourceSets.getByName("main").java.srcDirs)
+    }
+
+    artifacts {
+        archives(sourcesJar)
+    }
+}
+
 afterEvaluate {
     publishing {
         publications {

--- a/tor-droid-make.sh
+++ b/tor-droid-make.sh
@@ -210,6 +210,7 @@ release()
     aar=${artifact}-${version}.aar
     cd tor-android-binary/build/outputs/aar/
     mv ../../libs/${artifact}-${version}-*.jar ./
+    mv ../../intermediates/java_doc_jar/release/release-javadoc.jar ./${artifact}-${version}-javadoc.jar
     mv *-release.aar $aar
     buildinfo $artifact $version $aar
     pom $artifact $version


### PR DESCRIPTION
The build script tor-droid-make.sh fails when building a release because sourcesJar is now undefined.

fixes #165 