### PR TITLE
min NDK version in Makefile for 16 KB page sizes

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -26,7 +26,7 @@ endif
 
 # matching NDK revisions are required for reproducible builds
 NDK_REVISION := $(shell sed -n 's,^Pkg.Revision *= *\([^ ]*\),\1,p' $(ANDROID_NDK_HOME)/source.properties)
-NDK_REQUIRED_REVISION := 25.2.9519653
+NDK_REQUIRED_REVISION := 28.1.13356709
 MIN_NDK_VERSION := 24
 NDK_PLATFORM_LEVEL := 24
 ifeq ($(shell test $(MIN_NDK_VERSION) -gt $(firstword $(subst ., ,$(NDK_REVISION))); echo $$?),0)


### PR DESCRIPTION
This bumps the NDK up to r28 as per https://github.com/guardianproject/orbot-android/issues/1361

In the past using a newer NDK caused us issues where code would be built but symbols would be missing at run time. Not seeing this here when building for my device with both:

```bash
./tor-droid-make.sh build -a arm64-v8a
./tor-droid-make.sh build -b release -a arm64-v8a
```

So looks good to me, but this doesn't need to be merged in imminently for our next release with tor 0.4.8.17

Please test! 