### PR TITLE
Fix getting version string for release builds

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -291,7 +291,7 @@ ifneq ($(DEBUG), 1)
 	$(EXTERNAL_ROOT)/bin/termux-elf-cleaner --api-level $(NDK_PLATFORM_LEVEL) $(INSTALL_DIR)/libtor.so
 	ls -l  $(INSTALL_DIR)/libtor.so
 endif
-	echo "Checking for TorService java bindings in libtor.so:"
+	@echo "Checking for TorService java bindings in libtor.so:"
 	grep "Java_org_torproject_jni_TorService" $(INSTALL_DIR)/libtor.so
 
 	# this requires unit tests to run, uncomment when CI or anything uses these tests like they did before

--- a/tor-android-binary/build.gradle.kts
+++ b/tor-android-binary/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
 }
 
 tasks.register<Jar>("sourcesJar") {
-    archiveBaseName.set("tor-android-" + getVersionName())
+    archiveBaseName.set("tor-android-" + getVersionName().get())
     archiveClassifier.set("sources")
     from(android.sourceSets.getByName("main").java.srcDirs)
 }
@@ -94,7 +94,7 @@ tasks.dokkaGeneratePublicationJavadoc.configure {
 
 tasks.register<Jar>("javadocJar") {
     dependsOn(tasks.dokkaGeneratePublicationJavadoc)
-    archiveBaseName.set("tor-android-" + getVersionName())
+    archiveBaseName.set("tor-android-" + getVersionName().get())
     archiveClassifier.set("javadoc")
     from(tasks.dokkaGeneratePublicationJavadoc.flatMap { it.outputDirectory })
 }


### PR DESCRIPTION
Fix getting the version strings to create release builds.
Fix an echo statement from being shown twice.

