### PR TITLE
Fix sourcesJar task with AGP 9.2.0

### DIFF
--- a/tor-android-binary/build.gradle.kts
+++ b/tor-android-binary/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 tasks.register<Jar>("sourcesJar") {
     archiveBaseName.set("tor-android-" + getVersionName().get())
     archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
+    from("src/main/java")
 }
 
 tasks.dokkaGeneratePublicationJavadoc.configure {


### PR DESCRIPTION
AGP 9.2.0 introduced breaking changes in its internal APIs, specifically around `AndroidLibrarySourceSet` types. The cast fails because the actual implementation class
(`DefaultAndroidLibrarySourceSet_Decorated`) no longer implements the expected interface (`AndroidLibrarySourceSet`).