### PR TITLE
Fix dependencyResolutionManagement

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS) // or PREFER_PROJECT
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Fix resolving dependencies when building the sample app.

When `dependencyResolutionManagement` is used in `settings.gradle.kts`, it  overrides all repository declarations in individual build files.