### PR TITLE
Fix NullPointerException in getPortFromGetInfo when getInfo() fails

### DIFF
--- a/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
+++ b/tor-android-binary/src/main/java/org/torproject/jni/TorService.java
@@ -413,7 +413,7 @@ public class TorService extends Service {
 
     private int getPortFromGetInfo(String key) {
         var value = getInfo(key);
-        if (value.trim().isEmpty()) return 0; // port is disabled
+        if (value == null || value.trim().isEmpty()) return 0; // port is disabled, or getInfo() failed
         return Integer.parseInt(value.substring(value.lastIndexOf(':') + 1, value.length() - 1));
     }
 


### PR DESCRIPTION
`getPortFromGetInfo()` can throw an uncaught NullPointerException.

`getInfo(String)` is documented as returning "the value or null on error", and it does return null whenever `torControlConnection.getInfo(key)` throws an IOException talking to the control port (it catches, logs, and falls through to `return null`). But `getPortFromGetInfo()` calls it and goes straight to `value.trim()` with no null check:

    private int getPortFromGetInfo(String key) {
        var value = getInfo(key);
        if (value.trim().isEmpty()) return 0; // port is disabled
        return Integer.parseInt(value.substring(value.lastIndexOf(':') + 1, value.length() - 1));
    }

It is called from `controlPortThread` right after `authenticate()`:

    socksPort = getPortFromGetInfo("net/listeners/socks");
    httpTunnelPort = getPortFromGetInfo("net/listeners/httptunnel");

and that thread only catches `IOException | ArrayIndexOutOfBoundsException | InterruptedException`, not NPE. So any control-port hiccup during those two GETINFO calls (a dropped connection, a short read) makes `getInfo()` return null, and the null `value.trim()` becomes an uncaught NPE on that thread instead of the IOException path the method is clearly built to handle. An uncaught exception on any thread takes down the app process by default on Android.

The fix treats null the same as the empty case: the port just isn't available, return 0.

I verified it with a small standalone Java harness that runs the exact method body with `value = null` (what `getInfo()` returns on failure): before, it throws the NPE on `String.trim()`; after, same input returns 0, no exception. I don't have the Android SDK/NDK here, so I have not built the AAR or reproduced it on a device, this is a static read of the call chain plus a harness proof of the method logic. If you can confirm against a real control-port failure it would be worth a look.
